### PR TITLE
Array{T,1} -> Vector{T} and Array{T,2} -> Matrix{T}

### DIFF
--- a/HSVGP.jl/src/elbos.jl
+++ b/HSVGP.jl/src/elbos.jl
@@ -50,7 +50,7 @@ Warning: Untested, may not work yet. In progress.
 
 Returns scalar real value of the elbo
 """
-function inference_elbo_local(x, y, N::Int64, inf_obj::Inference_obj, global_pred::Array{SVGP_params,1})
+function inference_elbo_local(x, y, N::Int64, inf_obj::Inference_obj, global_pred::Vector{SVGP_params})
     elbo = svgp_elbo(x, y, N, inf_obj)
     
     term5 = 0.0

--- a/HSVGP.jl/src/fit_mpi_hsvgp.jl
+++ b/HSVGP.jl/src/fit_mpi_hsvgp.jl
@@ -284,8 +284,8 @@ function mpifit_hsvgp(get_data, n_parts, n_dims, bounds_low, bounds_high;
 
             if is_message
                 MPI.Recv!(msg, 0, 8, comm);
-                global msg = convert(Array{Int64,1}, msg)
-                global msg2 = convert(Array{Int64,1}, ones(msg[1]));
+                global msg = convert(Vector{Int64}, msg)
+                global msg2 = convert(Vector{Int64}, ones(msg[1]));
                 #println("process ", myrank, "recieved first message ", msg);
                 MPI.Recv!(msg2, 0, 10+myrank, comm);
                 global msg2 = msg2;
@@ -308,7 +308,7 @@ function mpifit_hsvgp(get_data, n_parts, n_dims, bounds_low, bounds_high;
         if myrank == root
             #Select random local partition for batch
             aa = collect(1:n_parts);
-            selection = convert(Array{Int64,1}, zeros(n_batch));
+            selection = convert(Vector{Int64}, zeros(n_batch));
             StatsBase.efraimidis_ares_wsample_norep!(aa, wts, selection)
             part_split_curr = [intersect(part_split[ii], selection) for ii in 1:(mysize-1)];
             wts[selection] .= 0;
@@ -373,8 +373,8 @@ function mpifit_hsvgp(get_data, n_parts, n_dims, bounds_low, bounds_high;
             #println("process ", myrank, "message recieved? ", is_message)
             if is_message
                 MPI.Recv!(msg, 0, 8, comm);
-                global msg = convert(Array{Int64,1}, msg);
-                global msg2 = convert(Array{Int64,1}, ones(msg[1]));
+                global msg = convert(Vector{Int64}, msg);
+                global msg2 = convert(Vector{Int64}, ones(msg[1]));
                 #println("process ", myrank, "recieved first message ", msg);
                 MPI.Recv!(msg2, 0, 10+myrank, comm);
                 global msg2 = msg2;

--- a/HSVGP.jl/src/likelihoods.jl
+++ b/HSVGP.jl/src/likelihoods.jl
@@ -4,7 +4,7 @@ Evaluate Gaussian likelihood for SVGP
 
 Returns scalar real value of the marginal likelihood
 """
-function gaussian_likelihood(x, y, gp_params::Array{SVGP_params,1})
+function gaussian_likelihood(x, y, gp_params::Vector{SVGP_params})
     n, p  = size(x)
     sigsq = exp(gp_params[1].log_sigma[1])^2
 
@@ -29,7 +29,7 @@ Monte Carlo approximation to marginal likelihood, sampling from variational dist
 
 Returns scalar real value of the marginal likelihood
 """
-function poisson_likelihood(x, y, gp_params::Array{SVGP_params,1})
+function poisson_likelihood(x, y, gp_params::Vector{SVGP_params})
     n, p         = size(x)
     p_mean, p_sd = pred_vgp(x, gp_params[1])
     
@@ -54,7 +54,7 @@ WARNING: Likely has some serious support issues right now. Need checking on boun
 
 Returns scalar real value of the marginal likelihood
 """
-function gev_likelihood(x, y, gp_params::Array{SVGP_params,1})
+function gev_likelihood(x, y, gp_params::Vector{SVGP_params})
     n, p     = size(x)
     p_params = [pred_vgp(x, svgp) for svgp in gp_params]
     
@@ -81,7 +81,7 @@ GEV with shape parameter = 0. Does not have the support challenges that the GEV 
 
 Returns scalar real value of the marginal likelihood
 """
-function gumbel_likelihood(x, y, gp_params::Array{SVGP_params,1})
+function gumbel_likelihood(x, y, gp_params::Vector{SVGP_params})
     n, p     = size(x)
     p_params = [pred_vgp(x, svgp) for svgp in gp_params]
     
@@ -115,7 +115,7 @@ WARNING: Likely has some serious support issues right now. Need checking on boun
 Returns scalar real value of the marginal likelihood
 """
 function create_custom_likelihood(ll_func)
-    function cust_like(x, y, gp_params::Array{SVGP_params,1})
+    function cust_like(x, y, gp_params::Vector{SVGP_params})
         n, p     = size(x)
         p_params = [pred_vgp(x, svgp) for svgp in gp_params]
     

--- a/HSVGP.jl/src/likelihoods.jl
+++ b/HSVGP.jl/src/likelihoods.jl
@@ -115,23 +115,21 @@ WARNING: Likely has some serious support issues right now. Need checking on boun
 Returns scalar real value of the marginal likelihood
 """
 function create_custom_likelihood(ll_func)
-    function cust_like(x, y, gp_params::Vector{SVGP_params})
-        n, p     = size(x)
+    return function cust_like(x, y, gp_params::Vector{SVGP_params})
+        n, p = size(x)
         p_params = [pred_vgp(x, svgp) for svgp in gp_params]
-    
-        marg_like = 0
-        for ii in 1:16  # TODO: Hard coded num of sample for marginalization for now. Should make an argument.
-            param_samps   = [p_par[1] + p_par[2] .* randn(n) for p_par in p_params]
-        
-            new_like_term = sum( ll_func(x,y,param_samps) )
 
-            marg_like     = (ii-1.0)/ii * marg_like + 1. / ii * new_like_term
+        # TODO: Hard coded num of sample for marginalization for now. Should make an argument.
+        const num_mc_samples = 16
+
+        marg_like = 0.0
+        for ii in 1:num_mc_samples
+            param_samps = [p_par[1] + p_par[2] .* randn(n) for p_par in p_params]
+            marg_like += sum(ll_func(x, y, param_samps))
         end
         
-        marg_like /= 16.
+        marg_like /= num_mc_samples
         
         return marg_like
     end
-
-    return cust_like
 end

--- a/HSVGP.jl/src/mpi_comm.jl
+++ b/HSVGP.jl/src/mpi_comm.jl
@@ -1,4 +1,4 @@
-function send_inducing_points_to_global(xi_low::Array{Float64,2}, yi_low::Array{Float64,1}, root, comm)
+function send_inducing_points_to_global(xi_low::Matrix{Float64}, yi_low::Vector{Float64}, root, comm)
 
     smsg = MPI.Send(xi_low, root, 0, comm)
     # println("xi_low sent to root")
@@ -24,7 +24,7 @@ function receive_inducing_points_in_global(ni_low::Int64, p_low::Int64, recv_id,
 end #receive_inducing_points_in_global
 
 
-function send_prior_to_local(pred_data::Tuple{Array{Float64,1},Array{Float64,1}}, recv_id, comm)
+function send_prior_to_local(pred_data::Tuple{Vector{Float64},Vector{Float64}}, recv_id, comm)
     prior_mean, prior_sd = pred_data
 
     smsg = MPI.Send(prior_mean, recv_id, 2, comm)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PRISM
+[![HSVGP Build Status][hsvgp-ci-img]](https://github.com/lanl/PRISM/actions)
+[![Codecov][codecov-img]](https://codecov.io/gh/lanl/PRISM)
+
 Programming Repository for In Situ Modeling
 
 ![PRISM](prism.png)
@@ -15,3 +18,6 @@ contains tools for interfacing with large-scale scientific simulations written i
 allows the data scientist to construct analysis models in Julia without concern for the implementation details of the
 simulation capability. With these components, PRISM can be used to unlock the full scientific potential of next-generation
 HPC simulations.
+
+[hsvgp-ci-img]: https://github.com/lanl/PRISM/workflows/HSVGP-CI/badge.svg
+[codecov-img]: https://img.shields.io/codecov/c/github/lanl/PRISM/master.svg?label=codecov


### PR DESCRIPTION
Throughout the `HSVGP.jl`, `Array{T,1}` and `Array{T,2}` are used. Respectively, `Vector{T}` and `Matrix{T}` are preferred. Instances of the former were replaced with the latter.

Also added CI status badges to `PRISM/README.md`, for greater visibility.